### PR TITLE
Only display one of the InputSection instead of twelve

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,11 +11,7 @@ const App: React.FC = () => {
       <h1>Missing-Link Solve</h1>
       <div className="grid-container">
         {/* Repeat the InputSection component twelve times */}
-        {Array.from({ length: 12 }).map((_, index) => (
-          <InputSection
-            key={index}
-          />
-        ))}
+        <InputSection />
       </div>
     </div>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the rendering process by using a single instance of the `InputSection` component instead of multiple instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->